### PR TITLE
Init empty arrays

### DIFF
--- a/src/Spreadsheet.php
+++ b/src/Spreadsheet.php
@@ -14,10 +14,10 @@ class Spreadsheet
     protected $id;
 
     /** @var array */
-    protected $locales;
+    protected $locales = [];
 
     /** @var array */
-    protected $translations;
+    protected $translations = [];
 
     /** @var Api */
     protected $api;


### PR DESCRIPTION
Fixes a bug when using php 7.2

When the arrays are not initialised, the initial push fails.

> 7.2.0 count() will now yield a warning on invalid countable types passed to the array_or_countable parameter.