### PR TITLE
Fix travisCI PR builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ matrix:
       env: ILLUMINATE_VERSION=5.6.*
 
 before_install:
-    - openssl aes-256-cbc -K $encrypted_5affb966e7f5_key -iv $encrypted_5affb966e7f5_iv -in tests/fixtures/service-account.json.enc -out tests/fixtures/service-account.json -d
+    - [ "${TRAVIS_PULL_REQUEST}" = "false" ] && openssl aes-256-cbc -K $encrypted_5affb966e7f5_key -iv $encrypted_5affb966e7f5_iv -in tests/fixtures/service-account.json.enc -out tests/fixtures/service-account.json -d
     - composer require "illuminate/support:${ILLUMINATE_VERSION}" --no-update -v
     - composer require "illuminate/console:${ILLUMINATE_VERSION}" --no-update -v
     - composer require "illuminate/filesystem:${ILLUMINATE_VERSION}" --no-update -v

--- a/src/Spreadsheet.php
+++ b/src/Spreadsheet.php
@@ -14,10 +14,10 @@ class Spreadsheet
     protected $id;
 
     /** @var array */
-    protected $locales;
+    protected $locales = [];
 
     /** @var array */
-    protected $translations;
+    protected $translations = [];
 
     /** @var Api */
     protected $api;


### PR DESCRIPTION
Travis CI build fails on openssl when running builds for PR (encrypted variables were removed from runs for PR from forks). 
I tried to follow openframeworks/projectGenerator solution, and skip this step for PR builds 
as suggested in project issue:
  https://github.com/openframeworks/projectGenerator/issues/101
resolved in commit:
  https://github.com/openframeworks/projectGenerator/commit/b48e5859f2dfc5377f656beef72ec2e70f16f29b


