### PR TITLE
Update Writer.php

### DIFF
--- a/src/Translation/Writer.php
+++ b/src/Translation/Writer.php
@@ -97,7 +97,7 @@ class Writer
                 // For instance, we have `app.title` that is the same for each locale,
                 // We dont want to translate it to every locale, and prefer letting
                 // Laravel default back to the default locale.
-                if (empty($translation[$locale])) {
+                if (!isset($translation[$locale]) || strlen($translation[$locale]) == 0) {
                     continue;
                 }
 


### PR DESCRIPTION
Consider replacing empty with !isset || strlen == 0

there is a bug when translation value is "0"

if (empty($translation[$locale])) {
                    continue;
                }

                if (!isset($translation[$locale]) || strlen($translation[$locale]) == 0) {
                    continue;
                }