### PR TITLE
fix vendor subsequent skipped

### DIFF
--- a/src/Translation/Reader.php
+++ b/src/Translation/Reader.php
@@ -83,7 +83,8 @@ class Reader
     {
         foreach ($this->files->directories($path) as $directory) {
             if ($this->isVendorDirectory($directory)) {
-                return $this->scanVendorDirectory($directory);
+                $this->scanVendorDirectory($directory);
+                continue;
             }
 
             $this->loadTranslationsInDirectory($directory, $this->getLocaleFromDirectory($directory), null);


### PR DESCRIPTION
my English is hard to describe, I try to use code.

first
https://github.com/nikaia/translation-sheet/blob/master/src/Translation/Reader.php#L82
Stop the loop when you encounter the vendor

function directories
```php
    public function directories($directory)
    {
        $directories = [];

        foreach (Finder::create()->in($directory)->directories()->depth(0)->sortByName() as $dir) {
            $directories[] = $dir->getPathname();
        }
        
        return $directories;
    }
```
sortByName return
```
resources/lang/en
resources/lang/ja
resources/lang/ko
resources/lang/vendor -> stop work
resources/lang/zh-CN
```
Because, I modified to skip this loop
