### PR TITLE
Add support for Laravel 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
     ],
     "require": {
         "google/apiclient": "^2.1",
-        "illuminate/console": ">=5.8 <=6.0",
-        "illuminate/filesystem": ">=5.8 <=6.0",
-        "illuminate/support": ">=5.8 <=6.0"
+        "illuminate/console": "^5.8|^6.0",
+        "illuminate/filesystem": "^5.8|^6.0",
+        "illuminate/support": "^5.8|^6.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.11",


### PR DESCRIPTION
Hello,

This little PR change only the required dependencies to add support of the latest release of Laravel.

Tests ran fine locally.