### PR TITLE
fix(excludes) sends indexed array when excluding files to google api

### DIFF
--- a/src/Pusher.php
+++ b/src/Pusher.php
@@ -2,8 +2,8 @@
 
 namespace Nikaia\TranslationSheet;
 
-use Illuminate\Support\Str;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 use Nikaia\TranslationSheet\Commands\Output;
 use Nikaia\TranslationSheet\Sheet\TranslationsSheet;
 use Nikaia\TranslationSheet\Translation\Reader;
@@ -43,7 +43,7 @@ class Pusher
         $this->translationsSheet->updateHeaderRow();
 
         $this->output->writeln('<comment>Writing translations in the spreadsheet</comment>');
-        $this->translationsSheet->writeTranslations($translations->toArray());
+        $this->translationsSheet->writeTranslations($translations->all());
 
         $this->output->writeln('<comment>Styling document</comment>');
         $this->translationsSheet->styleDocument();
@@ -58,10 +58,10 @@ class Pusher
         return $this->transformer
             ->setLocales($this->translationsSheet->getSpreadsheet()->getLocales())
             ->transform($this->reader->scan())
-            ->when(is_array($excludePatterns) && !empty($excludePatterns), function (Collection $collection) use ($excludePatterns) {
+            ->when(is_array($excludePatterns) && ! empty($excludePatterns), function (Collection $collection) use ($excludePatterns) {
                 return $collection->reject(function ($item) use ($excludePatterns) {
                     return Str::is($excludePatterns, $item[0] /* full key */);
-                });
+                })->values();
             });
     }
 }

--- a/tests/Feature/ExcludePatternsTest.php
+++ b/tests/Feature/ExcludePatternsTest.php
@@ -1,5 +1,8 @@
 <?php
 
+use Nikaia\TranslationSheet\Commands\Prepare;
+use Nikaia\TranslationSheet\Commands\Push;
+use Nikaia\TranslationSheet\Commands\Setup;
 use Nikaia\TranslationSheet\Pusher;
 use Nikaia\TranslationSheet\Test\FeatureTestCase;
 
@@ -20,14 +23,30 @@ class ExcludeFilterTest extends FeatureTestCase
 
         config()->set('translation_sheet.exclude', [
             'foo::*',
-            'validation*'
+            'validation*',
         ]);
         $this->assertCount(0, $pusher->getScannedAndTransformedTranslations());
-
 
         config()->set('translation_sheet.exclude', [
             'foo::*',
         ]);
         $this->assertCount(4, $pusher->getScannedAndTransformedTranslations());
+    }
+
+    /** @test */
+    public function it_exludes_correctly_the_specified_patterns_for_push()
+    {
+        /** @var Pusher $pusher */
+        $pusher = resolve(Pusher::class);
+        config()->set('translation_sheet.exclude', [
+            'foo::*',
+        ]);
+        $this->assertIsArray(json_decode($pusher->getScannedAndTransformedTranslations()->toJson()));
+
+        $this->resetSpreadsheet();
+
+        foreach ([new Setup(), new Prepare(), new Push()] as $command) {
+            $this->artisan($command->getName())->assertExitCode(0);
+        }
     }
 }


### PR DESCRIPTION
It fails the request to google api
because it tries to send the json payload as an object instead to an array


Error example
```
Invalid JSON payload received. Unknown name \"2\" at 'data.values': Cannot find field.
Invalid JSON payload received. Unknown name \"3\" at 'data.values': Cannot find field.
Invalid JSON payload received. Unknown name \"4\" at 'data.values': Cannot find field.
Invalid JSON payload received. Unknown name \"5\" at 'data.values': Cannot find field.
```
