### PR TITLE
Recognize json or php format while reading translations files

### DIFF
--- a/src/Translation/Reader.php
+++ b/src/Translation/Reader.php
@@ -157,7 +157,7 @@ class Reader
      */
     private function loadTranslations($locale, $group, $namespace, $file)
     {
-        if ($this->translationSheet->isExtraSheet()) {
+        if (pathinfo($file, PATHINFO_EXTENSION) === 'json') {
             $translations = Arr::dot(json_decode(file_get_contents($file), true));
         } else {
             $translations = Arr::dot($this->app['translator']->getLoader()->load($locale, $group, $namespace));


### PR DESCRIPTION
Hi.
There is a problem if you have extra translations in PHP format. I guess it would be better to recognize file extensions while reading.