### PR TITLE
bump google/apiclient version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "google/apiclient": "^2.1",
+        "google/apiclient": "^2.15",
         "illuminate/console": "~5.8.0|^6.0|^7.0|^8.0|^v9.0|^10.0",
         "illuminate/filesystem": "~5.8.0|^6.0|^7.0|^8.0|^v9.0|^10.0",
         "illuminate/support": "~5.8.0|^6.0|^7.0|^8.0|^v9.0|^10.0"


### PR DESCRIPTION
bump to the latest google/apiclient version.

Motivation:
versions bellow 2.15 allows [firebase/php-jwt](https://packagist.org/packages/firebase/php-jwt) bellow 6.0 (https://github.com/advisories/GHSA-8xf4-w7qw-pjjw)